### PR TITLE
Change region parameter to be required

### DIFF
--- a/alibabacloud_oss_v2/config.py
+++ b/alibabacloud_oss_v2/config.py
@@ -6,7 +6,7 @@ class Config(object):
     """Configuration for client."""
     def __init__(
         self,
-        region: str = None,
+        region: str,
         endpoint: Optional[str] = None,
         signature_version: Optional[str] = None,
         credentials_provider: Optional[CredentialsProvider] = None,


### PR DESCRIPTION
The region in the comment is required, but the default value of the parameter region is allowed to be None.