### PR TITLE
Refactor iter_bytes to yield chunks asynchronously

### DIFF
--- a/alibabacloud_oss_v2/aio/aio_utils.py
+++ b/alibabacloud_oss_v2/aio/aio_utils.py
@@ -334,6 +334,10 @@ class AsyncStreamBodyReader(AsyncStreamBody):
     async def __aexit__(self, *args: Any) -> None:
         await self._response.__exit__(*args)
 
+    def __aiter__(self) -> AsyncIterator[bytes]:
+        """Allow the body to be used in an 'async for' loop."""
+        return self.iter_bytes()
+
     @property
     def is_closed(self) -> bool:
         return self._response.is_closed

--- a/alibabacloud_oss_v2/aio/aio_utils.py
+++ b/alibabacloud_oss_v2/aio/aio_utils.py
@@ -355,4 +355,5 @@ class AsyncStreamBodyReader(AsyncStreamBody):
         await self._response.close()
 
     async def iter_bytes(self, **kwargs: Any) -> AsyncIterator[bytes]:
-        return self._response.iter_bytes(**kwargs)
+        async for chunk in self._response.iter_bytes(**kwargs):
+            yield chunk


### PR DESCRIPTION
This PR refactors the `AsyncStreamBodyReader.iter_bytes` method to use `yield` instead of returning a coroutine. This aligns the method with standard Python asynchronous generator patterns and improves type safety.
And added `__aiter__` to the base class, delegating to `iter_bytes()`. This allows users to iterate over the body directly.

## Details
Previously, `iter_bytes` acted as a coroutine factory that returned an iterator. This required users to oddly `await` the method call before iterating:
```python
# Old behavior
async for chunk in await result.body.iter_bytes():
```
This PR changes the implementation to yield chunks directly from the underlying response. This simplifies the usage and fixes potential type inference issues where static analysis tools (like Pyright/Pylance) would confuse the coroutine return type with the iterator itself.

## Breaking Change!!!

This is a breaking change for the calling convention of `iter_bytes`.
* **Before**: Users had to use `await` on the function call.
  ```python
  # Old usage
  async for chunk in await result.body.iter_bytes():
      pass
  ```
* **After**: Users must NOT use `await` on the function call.
  ```python
  # New standard usage
  async for chunk in result.body.iter_bytes():
      pass
  ```
  Note: Existing code using `await result.body.iter_bytes()` will raise a `TypeError: object async_generator can't be used in 'await' expression` after this change.
