### PR TITLE
fix(signer): attach security token only when present

### DIFF
--- a/alibabacloud_oss_v2/signer/v4.py
+++ b/alibabacloud_oss_v2/signer/v4.py
@@ -52,7 +52,7 @@ class SignerV4(Signer):
         request.headers.update({'Date': datetime_now_rfc2822})
 
         # Credentials information
-        if cred.security_token is not None:
+        if cred.security_token:
             request.headers.update(
                 {'x-oss-security-token': cred.security_token})
 


### PR DESCRIPTION
This change updates the `security_token` check to be more Pythonic and correctly handles the edge case where the token is an empty string.

**Context**:
https://github.com/aliyun/aliyun-mns-python-sdk/pull/10 - Both the MNS SDK and OSS SDK currently do not cover all `security_token` scenarios. They also perform the check in the opposite way, which makes it impossible to use them seamlessly with alibabacloud-credentials.